### PR TITLE
Remove hardcoded values for redis options in scheduler inspector

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -49,6 +49,7 @@ type Server struct {
 // NewServer returns a new server.
 func NewServer(port int64,
 	redis *storage.RedisStorage,
+	redisOpts asynq.RedisClientOpt,
 	client *asynq.Client,
 	inspector *asynq.Inspector,
 	vaultFilePath string,
@@ -81,6 +82,7 @@ func NewServer(port int64,
 			db,
 			logrus.WithField("service", "scheduler").Logger,
 			client,
+			redisOpts,
 		)
 		schedulerService.Start()
 		logrus.Info("Scheduler service started")

--- a/cmd/vultisigner/main.go
+++ b/cmd/vultisigner/main.go
@@ -49,6 +49,7 @@ func main() {
 	server := api.NewServer(
 		cfg.Server.Port,
 		redisStorage,
+		redisOptions,
 		client,
 		inspector,
 		cfg.Server.VaultsFilePath,

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -21,16 +21,13 @@ type SchedulerService struct {
 	done      chan struct{}
 }
 
-func NewSchedulerService(db storage.DatabaseStorage, logger *logrus.Logger, client *asynq.Client) *SchedulerService {
+func NewSchedulerService(db storage.DatabaseStorage, logger *logrus.Logger, client *asynq.Client, redisOpts asynq.RedisClientOpt) *SchedulerService {
 	if db == nil {
 		logger.Fatal("database connection is nil")
 	}
 
 	// create inspector using the same Redis configuration as the client
-	inspector := asynq.NewInspector(asynq.RedisClientOpt{
-		Addr: "localhost:6379", // redis configuration
-		DB:   1,                // redis DB number
-	})
+	inspector := asynq.NewInspector(redisOpts)
 
 	return &SchedulerService{
 		db:        db,


### PR DESCRIPTION
Fixing an issue in scheduler inspector, removing hardcoded values.