### PR TITLE
modify create & update endpoints to return, add plugin type to get en…

### DIFF
--- a/plugins-ui/src/modules/policy-form/services/policyService.ts
+++ b/plugins-ui/src/modules/policy-form/services/policyService.ts
@@ -43,7 +43,9 @@ const PolicyService = {
       const endpoint = "/plugin/policy";
       const newPolicy = await get(endpoint, {
         headers: {
-          public_key: "037c4092a5928c32722df3ac6d02955b20a868fcc58d03ef5e38b1589e09349257", // TODO: get Vault's pub key
+          plugin_type: "dca", // todo remove hardcoding once we have the marketplace
+          public_key:
+            "037c4092a5928c32722df3ac6d02955b20a868fcc58d03ef5e38b1589e09349257", // TODO: get Vault's pub key
         },
       });
       return newPolicy;

--- a/plugins-ui/src/modules/policy-form/utils/policy.util.ts
+++ b/plugins-ui/src/modules/policy-form/utils/policy.util.ts
@@ -7,9 +7,11 @@ export const generatePolicy = (
 ): PluginPolicy => {
   return {
     id: policyId,
-    public_key: "037c4092a5928c32722df3ac6d02955b20a868fcc58d03ef5e38b1589e09349257", // TODO: get Vault's pub key
+    public_key:
+      "037c4092a5928c32722df3ac6d02955b20a868fcc58d03ef5e38b1589e09349257", // TODO: get Vault's pub key
     plugin_type,
     policy: convertToStrings(policy),
+    signature: "", // todo this should be implemented
   };
 };
 

--- a/storage/db.go
+++ b/storage/db.go
@@ -8,10 +8,10 @@ import (
 type DatabaseStorage interface {
 	Close() error
 
-	InsertPluginPolicy(policyDoc types.PluginPolicy) error
+	InsertPluginPolicy(policyDoc types.PluginPolicy) (types.PluginPolicy, error)
 	GetPluginPolicy(id string) (types.PluginPolicy, error)
-	GetAllPluginPolicies(public_key string) ([]types.PluginPolicy, error)
-	UpdatePluginPolicy(policyDoc types.PluginPolicy) error
+	GetAllPluginPolicies(publicKey string, pluginType string) ([]types.PluginPolicy, error)
+	UpdatePluginPolicy(policyDoc types.PluginPolicy) (types.PluginPolicy, error)
 	DeletePluginPolicy(id string) error
 
 	CreateTimeTrigger(trigger types.TimeTrigger) error


### PR DESCRIPTION
Create and update policy endpoints now return the policy as a resource, this is needed for the frontend as optimisation to avoid request for updating on screen data.

The get all policies backend endpoint also requires plugin_type, to mitigate the case when there will be more than one plugin type.

Since plugin_version, policy_version and plugin_id are not customer editable properties, they should not be in the request, where user could do whatever with them.