### PR TITLE
Display only swap txs in the DCA UI

### DIFF
--- a/service/policy.go
+++ b/service/policy.go
@@ -162,7 +162,7 @@ func (s *PolicyService) GetPluginPolicyTransactionHistory(ctx context.Context, p
 		return []types.TransactionHistory{}, fmt.Errorf("invalid policy_id: %s", policyID)
 	}
 
-	history, err := s.db.GetTransactionHistory(ctx, policyUUID, 30, 0) // take the last 30 records and skip the first 0
+	history, err := s.db.GetTransactionHistory(ctx, policyUUID, "SWAP", 30, 0) // take the last 30 records and skip the first 0
 	if err != nil {
 		return []types.TransactionHistory{}, fmt.Errorf("failed to get policy history: %w", err)
 	}

--- a/storage/db.go
+++ b/storage/db.go
@@ -39,7 +39,7 @@ type DatabaseStorage interface {
 	UpdateTransactionStatusTx(ctx context.Context, dbTx pgx.Tx, txID uuid.UUID, status types.TransactionStatus, metadata map[string]interface{}) error
 	CreateTransactionHistory(ctx context.Context, tx types.TransactionHistory) (uuid.UUID, error)
 	UpdateTransactionStatus(ctx context.Context, txID uuid.UUID, status types.TransactionStatus, metadata map[string]interface{}) error
-	GetTransactionHistory(ctx context.Context, policyID uuid.UUID, take int, skip int) ([]types.TransactionHistory, error)
+	GetTransactionHistory(ctx context.Context, policyID uuid.UUID, transactionType string, take int, skip int) ([]types.TransactionHistory, error)
 	GetTransactionByHash(ctx context.Context, txHash string) (*types.TransactionHistory, error)
 
 	FindPlugins(ctx context.Context) ([]types.Plugin, error)

--- a/storage/postgres/db.go
+++ b/storage/postgres/db.go
@@ -135,16 +135,17 @@ func (p *PostgresBackend) UpdateTransactionStatus(ctx context.Context, txID uuid
 
 }
 
-func (p *PostgresBackend) GetTransactionHistory(ctx context.Context, policyID uuid.UUID, take int, skip int) ([]types.TransactionHistory, error) {
+func (p *PostgresBackend) GetTransactionHistory(ctx context.Context, policyID uuid.UUID, transactionType string, take int, skip int) ([]types.TransactionHistory, error) {
 	query := `
         SELECT id, policy_id, tx_body, tx_hash, status, created_at, updated_at, metadata, error_message
         FROM transaction_history
         WHERE policy_id = $1
+        AND metadata->>'transaction_type' = $2
         ORDER BY created_at DESC
-		LIMIT $2 OFFSET $3
+		LIMIT $3 OFFSET $4
     `
 
-	rows, err := p.pool.Query(ctx, query, policyID, take, skip)
+	rows, err := p.pool.Query(ctx, query, policyID, transactionType, take, skip)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
TASK: https://github.com/LimeChain/vultisig-mono/issues/138
- added filter in SQL to return transaction history only with the specified TRANSACTION_TYPE.